### PR TITLE
Pull Request Title: Implement Shuffling of Quiz Questions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,8 +1638,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3314,6 +3316,8 @@ dependencies = [
  "derive_more 1.0.0",
  "dioxus",
  "dioxus-logger",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ convert_case = "0.6.0"
 derive_more = { version = "1.0.0", features = ["is_variant"] }
 dioxus = { version = "=0.6.0-alpha.2", features = ["router"] }
 dioxus-logger = "0.5.1"
+getrandom = { version = "0.2.15", features = ["js"] }
+rand = "0.8.5"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 

--- a/src/components/start_menu.rs
+++ b/src/components/start_menu.rs
@@ -1,9 +1,11 @@
 use dioxus::prelude::*;
+use rand::{seq::SliceRandom, thread_rng};
 
 use crate::{components::quiz_topic::QuizTopic, types::Quiz};
 
 #[component]
 pub fn StartMenu() -> Element {
+    let mut rng = thread_rng();
     let quizzes: Vec<Quiz> = vec![
         Quiz {
             title: "Light Motor Vehicle",
@@ -23,7 +25,13 @@ pub fn StartMenu() -> Element {
             questions: serde_json::from_str(include_str!(".././../data/public-service.json"))
                 .unwrap(),
         },
-    ];
+    ]
+    .into_iter()
+    .map(|mut quiz| {
+        quiz.questions.shuffle(&mut rng);
+        quiz
+    })
+    .collect::<Vec<Quiz>>();
 
     rsx! {
         section { class: "flex flex-col xl:flex-row justify-between",


### PR DESCRIPTION
This pull request introduces a feature to shuffle the quiz questions each time a user starts a new quiz in the Driver’s Regulations Quiz for Trinidad & Tobago app. This enhancement aims to improve the learning experience by presenting questions in a random order, preventing memorization of the question sequence.

resolves #2 